### PR TITLE
Implement relevance filtering, quality evaluation, PDF download, and …

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -12,5 +12,12 @@ LANGFUSE_HOST=""
 
 # Email for OpenAlex polite pool (optional but recommended, raises rate limit)
 OPENALEX_MAILTO=""
-# Results fetched per source per query (default: 3);
+# Results fetched per source per query (default: 3)
 MAX_RESULTS_PER_SOURCE=""
+
+## Relevance filtering / quality control
+
+# Minimum number of REL/REL+ papers required to pass quality check (default: 3)
+MIN_REL_PAPERS=""
+# Maximum number of search retry iterations before accepting with a quality warning (default: 3)
+MAX_SEARCH_ITERATIONS=""

--- a/main.py
+++ b/main.py
@@ -1,9 +1,15 @@
 import logging
 import time
+import uuid
 
 import streamlit as st
 
-from src.agentic_workflow import AgenticLiteratureReview
+from src.agentic_workflow import (
+    AgenticLiteratureReview,
+    NoRelevantPapersFound,
+    set_search_progress_callback,
+    set_summarize_progress_callback,
+)
 from src.session_store import delete_session, list_sessions, load_session, make_session, save_session
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -84,37 +90,58 @@ with st.sidebar:
         st.caption("No saved runs yet.")
 
     st.divider()
-    st.caption("Typical runtime: 60-90 seconds.")
-    st.caption("Searches arXiv and synthesizes results using an LLM.")
+    st.caption("Typical runtime: 2-4 minutes.")
+    st.caption("Searches arXiv, filters for relevance, and synthesizes results using an LLM.")
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+_RELEVANCE_BADGE = {
+    "REL+": "🟢 REL+",
+    "REL":  "🔵 REL",
+    "REL-": "🟡 REL-",
+    "NOT_REL": "🔴 NOT_REL",
+    "":     "",
+}
+
 NODE_TO_STEP = {
-    "expand_topic": "planning",
-    "search": "search",
-    "compose_review": "composing",
+    "expand_topic":           "planning",
+    "search":                 "search",
+    "filter_relevance":       "filtering",
+    "evaluate_quality":       "evaluating",
+    "form_additional_queries": "retry_search",
+    "download_and_summarize": "summarizing",
+    "compose_review":         "composing",
 }
 
 
-def run_pipeline(t):
-    alr = AgenticLiteratureReview(topic=t)
+def run_pipeline(t: str, session_id: str):
+    alr = AgenticLiteratureReview(topic=t, session_id=session_id)
     for node_name, result in alr.run():
         step = NODE_TO_STEP.get(node_name)
         if step:
             yield step, result
 
 
-def display_results(papers, review, footer):
+def display_results(papers, review, footer, quality_warning=None):
+    if quality_warning:
+        st.warning(f"⚠️ Quality notice: {quality_warning}")
+
     col_papers, col_review = st.columns([2, 3], gap="large")
 
     with col_papers:
         st.subheader("Retrieved papers")
         for p in papers:
-            with st.expander(p["title"]):
+            badge = _RELEVANCE_BADGE.get(p.get("relevance", ""), "")
+            label = f"{badge}  {p['title']}" if badge else p["title"]
+            with st.expander(label):
                 st.caption(f"{p['authors']} · {p['published_date']}")
-                st.write(p["abstract"])
-                st.link_button("View on arXiv", p["url"])
+                if p.get("summary") and p["summary"] != p.get("abstract", ""):
+                    st.markdown(p["summary"])
+                else:
+                    st.write(p["abstract"])
+                st.link_button("View on arXiv / DOI", p["url"])
                 if p.get("citation"):
                     with st.expander("BibTeX"):
                         st.code(p["citation"], language="bibtex")
@@ -138,18 +165,61 @@ def display_results(papers, review, footer):
 # ---------------------------------------------------------------------------
 st.title("Agentic Literature Review Generator")
 
+def _open_search_status(steps_area, label: str, expanded: bool):
+    """Open a search status container with an inline progress bar. Returns (status, progress_placeholder)."""
+    status = steps_area.status(label, state="running", expanded=expanded)
+    with status:
+        progress_ph = st.empty()
+    return status, progress_ph
+
+
+def _register_search_progress(progress_ph):
+    """Register a callback that updates *progress_ph* on each query."""
+    def _cb(current: int, total: int, query: str) -> None:
+        if total > 0:
+            progress_ph.progress(
+                current / total,
+                text=f"Query {current} / {total} — *{query[:90]}*",
+            )
+    set_search_progress_callback(_cb)
+
+
+def _open_summarize_status(steps_area):
+    """Open summarize status container with an inline progress bar. Returns (status, progress_placeholder)."""
+    status = steps_area.status("Downloading & summarizing papers...", state="running", expanded=True)
+    with status:
+        progress_ph = st.empty()
+    return status, progress_ph
+
+
+def _register_summarize_progress(progress_ph):
+    """Register a callback that updates *progress_ph* on each paper."""
+    def _cb(current: int, total: int, title: str) -> None:
+        if total > 0:
+            progress_ph.progress(
+                current / total,
+                text=f"Paper {current} / {total} — *{title[:80]}*",
+            )
+    set_summarize_progress_callback(_cb)
+
+
 if run_btn:
     start = time.time()
+    session_id = str(uuid.uuid4())
     steps_area = st.container()
-    statuses = {}
+    statuses: dict[str, st.delta_generator.DeltaGenerator] = {}
     statuses["planning"] = steps_area.status("Expanding topic...", state="running", expanded=True)
 
     directions_saved = None
     papers_saved = None
     review_saved = None
+    quality_warning_saved = None
+    search_count = 0
+    _search_progress_ph = None   # progress placeholder for current search status
+    _summ_progress_ph = None     # progress placeholder for summarize status
 
     try:
-        for step_key, result in run_pipeline(topic):
+        for step_key, result in run_pipeline(topic, session_id):
 
             if step_key == "planning":
                 directions_saved = result["directions"]
@@ -157,18 +227,70 @@ if run_btn:
                     for i, d in enumerate(directions_saved, 1):
                         st.markdown(f"**{i}.** {d}")
                 statuses["planning"].update(
-                    label=f"Topic planning - {len(directions_saved)} directions",
+                    label=f"Topic planning — {len(directions_saved)} directions",
                     state="complete",
                     expanded=False,
                 )
-                statuses["search"] = steps_area.status("Searching arXiv...", state="running", expanded=True)
+                statuses["search"], _search_progress_ph = _open_search_status(
+                    steps_area, "Searching arXiv and OpenAlex...", expanded=True
+                )
+                _register_search_progress(_search_progress_ph)
+                search_count = 1
 
             elif step_key == "search":
-                papers_saved = result["search_results"]
-                with statuses["search"]:
-                    st.caption(f"Retrieved {len(papers_saved)} papers.")
+                set_search_progress_callback(None)
+                papers_saved = result.get("search_results") or []
                 statuses["search"].update(
-                    label=f"Paper search - {len(papers_saved)} papers retrieved",
+                    label=f"Paper search (iteration {search_count}) — {len(papers_saved)} papers",
+                    state="complete",
+                    expanded=False,
+                )
+                statuses["filtering"] = steps_area.status("Filtering for relevance...", state="running", expanded=False)
+
+            elif step_key == "filtering":
+                papers_saved = result.get("search_results") or []
+                rel_plus = sum(1 for p in papers_saved if p.get("relevance") == "REL+")
+                rel = sum(1 for p in papers_saved if p.get("relevance") == "REL")
+                rel_minus = sum(1 for p in papers_saved if p.get("relevance") == "REL-")
+                statuses["filtering"].update(
+                    label=f"Relevance filtering — {len(papers_saved)} papers kept (REL+:{rel_plus} REL:{rel} REL-:{rel_minus})",
+                    state="complete",
+                    expanded=False,
+                )
+                statuses["evaluating"] = steps_area.status("Evaluating coverage...", state="running", expanded=False)
+
+            elif step_key == "evaluating":
+                quality_warning_saved = result.get("quality_warning")
+                quality_ok = result.get("quality_ok")
+                if quality_ok:
+                    statuses["evaluating"].update(
+                        label="Coverage evaluation — quality OK",
+                        state="complete",
+                        expanded=False,
+                    )
+                    statuses["summarizing"], _summ_progress_ph = _open_summarize_status(steps_area)
+                    _register_summarize_progress(_summ_progress_ph)
+                else:
+                    statuses["evaluating"].update(
+                        label="Coverage evaluation — insufficient, retrying...",
+                        state="complete",
+                        expanded=False,
+                    )
+
+            elif step_key == "retry_search":
+                search_count += 1
+                statuses["search"], _search_progress_ph = _open_search_status(
+                    steps_area,
+                    f"Searching for more papers (iteration {search_count})...",
+                    expanded=True,
+                )
+                _register_search_progress(_search_progress_ph)
+
+            elif step_key == "summarizing":
+                set_summarize_progress_callback(None)
+                papers_saved = result.get("search_results") or []
+                statuses["summarizing"].update(
+                    label=f"Summarization — {len(papers_saved)} papers summarized",
                     state="complete",
                     expanded=False,
                 )
@@ -178,22 +300,38 @@ if run_btn:
                 review_saved = result["review"]
                 elapsed = time.time() - start
                 statuses["composing"].update(
-                    label="Review composition - complete",
+                    label="Review composition — complete",
                     state="complete",
                     expanded=False,
                 )
                 word_count = len(review_saved.split())
-                footer = f"Generated in {elapsed:.0f}s - {word_count} words - {len(papers_saved)} papers"
-                display_results(papers_saved, review_saved, footer)
+                footer = f"Generated in {elapsed:.0f}s · {word_count} words · {len(papers_saved)} papers"
+                display_results(papers_saved, review_saved, footer, quality_warning_saved)
 
         st.success(f"Pipeline complete in {time.time() - start:.0f}s.")
 
         if directions_saved and papers_saved and review_saved:
-            session = make_session(topic, directions_saved, papers_saved, review_saved)
+            session = make_session(
+                topic,
+                directions_saved,
+                papers_saved,
+                review_saved,
+                session_id=session_id,
+                quality_warning=quality_warning_saved,
+            )
             save_session(session)
             st.session_state.loaded_session_id = session.id
             st.session_state.new_topic_mode = False
             st.rerun()
+
+    except NoRelevantPapersFound as e:
+        for s in statuses.values():
+            try:
+                s.update(state="error")
+            except Exception:
+                pass
+        st.error(f"No relevant papers found: {e}")
+        logging.exception("No papers found")
 
     except Exception as e:
         for s in statuses.values():
@@ -210,8 +348,13 @@ elif st.session_state.loaded_session_id:
         date_str = session.created_at[:16].replace("T", " ")
         st.info(f"Saved run: **{session.name}** ({date_str})")
         word_count = len(session.review.split())
-        footer = f"{word_count} words - {len(session.search_results)} papers - saved {date_str}"
-        display_results(session.search_results, session.review, footer)
+        footer = f"{word_count} words · {len(session.search_results)} papers · saved {date_str}"
+        display_results(
+            session.search_results,
+            session.review,
+            footer,
+            getattr(session, "quality_warning", None),
+        )
     except Exception as e:
         st.error(f"Failed to load session: {e}")
         st.session_state.loaded_session_id = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,14 @@ dependencies = [
     "langfuse>=4.0.0",
     "langgraph>=1.1.2",
     "streamlit>=1.55.0",
+    "pypdf>=4.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-mock>=3.15.1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/agentic_workflow.py
+++ b/src/agentic_workflow.py
@@ -1,21 +1,68 @@
+import os
+import re
+import threading
+import time
+from collections.abc import Callable
 from logging import getLogger
+from pathlib import Path
 
 from dotenv import load_dotenv
-import os
 from langchain_openrouter import ChatOpenRouter
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.state import CompiledStateGraph
 
 from src.prompts import (
+    PROMPT_ADDITIONAL_QUERIES,
     PROMPT_COMPOSE_REVIEW,
     PROMPT_CONSTRUCT_SEARCH_QUERIES,
     PROMPT_EXPAND_TOPIC,
+    PROMPT_RELEVANCE_FILTER,
+    PROMPT_SUMMARIZE_PAPER,
 )
-from src.schemas import SearchQueries, State, Directions
+from src.schemas import RelevanceScores, SearchQueries, State, Directions
 from src.search_engine import SearchEngine
+from src.tools import download_arxiv_pdf, extract_pdf_text
 
 load_dotenv()
 logger = getLogger(__name__)
+
+_ARXIV_VERSION_RE = re.compile(r"v\d+$")
+
+MIN_REL_PAPERS = int(os.getenv("MIN_REL_PAPERS", "3"))
+MAX_SEARCH_ITERATIONS = int(os.getenv("MAX_SEARCH_ITERATIONS", "3"))
+
+SEARCH_ENGINE = SearchEngine()
+
+
+class NoRelevantPapersFound(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Progress callbacks
+# Each Streamlit session runs in its own thread, so threading.local() keeps
+# callbacks isolated between concurrent sessions.
+# ---------------------------------------------------------------------------
+
+_tls = threading.local()
+
+
+def set_search_progress_callback(cb: "Callable[[int, int, str], None] | None") -> None:
+    """Register a callback invoked before each search query.
+
+    Signature: ``cb(current: int, total: int, query: str)``
+    Pass ``None`` to unregister.
+    """
+    _tls.on_search_progress = cb
+
+
+def set_summarize_progress_callback(cb: "Callable[[int, int, str], None] | None") -> None:
+    """Register a callback invoked before each paper is summarized.
+
+    Signature: ``cb(current: int, total: int, title: str)``
+    Pass ``None`` to unregister.
+    """
+    _tls.on_summarize_progress = cb
 
 
 def wrap_logger(func):
@@ -26,15 +73,44 @@ def wrap_logger(func):
     return wrapper
 
 
-SEARCH_ENGINE = SearchEngine()
-
-
 def get_llm() -> ChatOpenRouter:
     return ChatOpenRouter(
         model=os.getenv("OPENROUTER_MODEL"),
         api_key=os.getenv("OPENROUTER_API_KEY"),
         base_url=os.getenv("OPENROUTER_BASE_URL"),
     )
+
+
+_TRANSIENT_ERROR_NAMES = {
+    "RemoteProtocolError",
+    "RemoteDisconnected",
+    "ConnectError",
+    "ConnectTimeout",
+    "ReadTimeout",
+    "IncompleteRead",
+    "ChunkedEncodingError",
+}
+
+
+def _is_transient(exc: Exception) -> bool:
+    return type(exc).__name__ in _TRANSIENT_ERROR_NAMES
+
+
+def _invoke_with_retry(llm: ChatOpenRouter, prompt: str, max_retries: int = 3) -> object:
+    """Invoke the LLM and retry on transient network errors with exponential backoff."""
+    for attempt in range(max_retries):
+        try:
+            return llm.invoke(prompt)
+        except Exception as exc:
+            if attempt < max_retries - 1 and _is_transient(exc):
+                wait = 5 * (2 ** attempt)
+                logger.warning(
+                    "LLM call transient error (attempt %d/%d), retrying in %ds: %s",
+                    attempt + 1, max_retries, wait, exc,
+                )
+                time.sleep(wait)
+            else:
+                raise
 
 
 @wrap_logger
@@ -44,8 +120,6 @@ def expand_topic(state: State) -> dict:
     result = llm_with_structure.invoke(
         PROMPT_EXPAND_TOPIC.render(topic=state["topic"]),
     )
-
-    # print(result)
 
     return {"directions": result["directions"]}
 
@@ -60,7 +134,6 @@ def form_search_queries(state: State) -> dict:
             directions=state["directions"],
         ),
     )
-    # print(result)
 
     return {"search_queries": result["search_queries"]}
 
@@ -68,18 +141,195 @@ def form_search_queries(state: State) -> dict:
 @wrap_logger
 def search(state: State) -> dict:
     queries = state["search_queries"]
-    logger.info("search: running %d queries", len(queries))
-    search_results = []
-    paper_ids = set()
+    # Accumulate results across iterations: seed from existing papers
+    existing = state.get("search_results") or []
+    paper_ids = {r["paper_id"] for r in existing}
+    search_results = list(existing)
+
+    total_queries = len(queries)
+    logger.info("search: running %d queries (existing papers: %d)", total_queries, len(existing))
     for i, query in enumerate(queries, 1):
-        logger.info("search: query %d/%d — %r", i, len(queries), query)
+        cb = getattr(_tls, "on_search_progress", None)
+        if cb:
+            cb(i, total_queries, query)
+        logger.info("search: query %d/%d — %r", i, total_queries, query)
         for result in SEARCH_ENGINE.search(query):
             if result["paper_id"] not in paper_ids:
+                # Initialise new schema fields for freshly retrieved papers
+                result["relevance"] = ""
+                result["completeness_score"] = 0
                 search_results.append(result)
                 paper_ids.add(result["paper_id"])
-        logger.info("search: after query %d/%d total papers so far: %d", i, len(queries), len(search_results))
+        logger.info("search: after query %d/%d total papers: %d", i, len(queries), len(search_results))
 
     return {"search_results": search_results}
+
+
+def _compute_completeness(paper: dict) -> int:
+    """Count non-empty fields relevant to completeness (max 7)."""
+    fields = ["title", "authors", "abstract", "doi", "url", "citation", "published_date"]
+    return sum(1 for f in fields if (paper.get(f) or "").strip())
+
+
+@wrap_logger
+def filter_relevance(state: State) -> dict:
+    papers = state.get("search_results") or []
+    if not papers:
+        logger.info("filter_relevance: no papers to filter")
+        return {"search_results": []}
+
+    # 1. Compute completeness scores
+    for paper in papers:
+        paper["completeness_score"] = _compute_completeness(paper)
+
+    # 2. Batch LLM call to score relevance
+    llm_with_structure = get_llm().with_structured_output(RelevanceScores)
+    scores_result = llm_with_structure.invoke(
+        PROMPT_RELEVANCE_FILTER.render(
+            topic=state["topic"],
+            directions=state["directions"],
+            papers=papers,
+        )
+    )
+
+    score_map: dict[str, str] = {
+        s["paper_id"]: s["relevance"]
+        for s in scores_result.get("scores", [])
+    }
+    logger.info("filter_relevance: received scores for %d/%d papers", len(score_map), len(papers))
+
+    # 3. Attach relevance labels
+    for paper in papers:
+        paper["relevance"] = score_map.get(paper["paper_id"], "REL-")  # default to REL- if missing
+
+    # 4. Filter
+    not_rel_removed = [p for p in papers if p["relevance"] != "NOT_REL"]
+    logger.info(
+        "filter_relevance: removed %d NOT_REL papers (%d remain)",
+        len(papers) - len(not_rel_removed),
+        len(not_rel_removed),
+    )
+
+    # Remove REL- papers with low completeness, but only if it doesn't empty the list
+    high_quality = [p for p in not_rel_removed if not (p["relevance"] == "REL-" and p["completeness_score"] < 3)]
+    if high_quality:
+        filtered = high_quality
+    else:
+        filtered = not_rel_removed  # keep them all rather than return empty
+    logger.info(
+        "filter_relevance: removed %d low-completeness REL- papers (%d remain)",
+        len(not_rel_removed) - len(filtered),
+        len(filtered),
+    )
+
+    return {"search_results": filtered}
+
+
+@wrap_logger
+def evaluate_quality(state: State) -> dict:
+    papers = state.get("search_results") or []
+    iteration = state.get("search_iteration", 0)
+
+    rel_count = sum(1 for p in papers if p.get("relevance") in {"REL", "REL+"})
+    logger.info(
+        "evaluate_quality: %d REL/REL+ papers out of %d total (iteration %d)",
+        rel_count, len(papers), iteration,
+    )
+
+    # Fail hard if no papers at all after exhausting retries
+    if not papers and iteration >= MAX_SEARCH_ITERATIONS:
+        raise NoRelevantPapersFound(
+            "No relevant papers found after maximum search iterations. "
+            "Try a broader or differently-phrased topic."
+        )
+
+    if rel_count >= MIN_REL_PAPERS:
+        logger.info("evaluate_quality: quality OK (%d >= %d)", rel_count, MIN_REL_PAPERS)
+        return {"quality_ok": True, "quality_warning": None}
+
+    if iteration < MAX_SEARCH_ITERATIONS:
+        logger.info(
+            "evaluate_quality: insufficient papers — will retry (iteration %d → %d)",
+            iteration, iteration + 1,
+        )
+        return {"quality_ok": False, "search_iteration": iteration + 1}
+
+    # Max iterations exhausted — accept with warning
+    warning = (
+        f"Only {rel_count} highly relevant paper(s) found after {iteration} search iteration(s). "
+        "The review may be of limited quality."
+    )
+    logger.warning("evaluate_quality: %s", warning)
+    return {"quality_ok": True, "quality_warning": warning}
+
+
+def _route_after_quality(state: State) -> str:
+    return "retry" if not state.get("quality_ok") else "proceed"
+
+
+@wrap_logger
+def form_additional_queries(state: State) -> dict:
+    llm_with_structure = get_llm().with_structured_output(SearchQueries)
+
+    result = llm_with_structure.invoke(
+        PROMPT_ADDITIONAL_QUERIES.render(
+            topic=state["topic"],
+            directions=state["directions"],
+            papers=state.get("search_results") or [],
+            previous_queries=state.get("search_queries") or [],
+        )
+    )
+
+    new_queries = result["search_queries"]
+    logger.info("form_additional_queries: generated %d new queries", len(new_queries))
+    return {"search_queries": new_queries}
+
+
+@wrap_logger
+def download_and_summarize(state: State) -> dict:
+    papers = state.get("search_results") or []
+    session_id = state.get("session_id") or "unknown"
+    pdf_dir = Path("sessions") / session_id / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    llm = get_llm()
+    updated_papers = []
+    total_papers = len(papers)
+
+    for idx, paper in enumerate(papers, 1):
+        cb = getattr(_tls, "on_summarize_progress", None)
+        if cb:
+            cb(idx, total_papers, paper["title"])
+        pid = paper["paper_id"]
+        arxiv_id = None if pid.startswith("openalex:") else pid
+
+        full_text = None
+        if arxiv_id:
+            base_id = _ARXIV_VERSION_RE.sub("", arxiv_id)
+            safe_name = base_id.replace("/", "_")
+            pdf_path = pdf_dir / f"{safe_name}.pdf"
+            if not pdf_path.exists():
+                download_arxiv_pdf(base_id, pdf_path)
+            if pdf_path.exists():
+                full_text = extract_pdf_text(pdf_path)
+
+        if full_text:
+            logger.info("summarize: using full text for %s (%d chars)", pid, len(full_text))
+        else:
+            logger.info("summarize: using abstract fallback for %s", pid)
+
+        summary = _invoke_with_retry(
+            llm,
+            PROMPT_SUMMARIZE_PAPER.render(
+                title=paper["title"],
+                full_text=full_text,
+                abstract=paper["abstract"],
+            ),
+        ).content.strip()
+
+        updated_papers.append({**paper, "summary": summary})
+
+    return {"search_results": updated_papers}
 
 
 @wrap_logger
@@ -97,31 +347,52 @@ def compose_review(state: State) -> dict:
         review.find("<review>") + len("<review>") : review.find("</review>")
     ]
 
-    # print(review)
-
     return {"review": review}
 
 
 class AgenticLiteratureReview:
-    def __init__(self, topic):
-        self.initial_state = State(topic=topic)
-        self.config = {"configurable": {"thread_id": "mock_thread_id"}}
+    def __init__(self, topic: str, session_id: str):
+        self.session_id = session_id
+        self.initial_state: State = {
+            "topic": topic,
+            "session_id": session_id,
+            "directions": None,
+            "search_queries": None,
+            "search_results": None,
+            "review": None,
+            "search_iteration": 0,
+            "quality_warning": None,
+            "quality_ok": None,
+        }
+        self.config = {"configurable": {"thread_id": session_id}}
         self.flow: CompiledStateGraph = self._make_workflow()
 
     def _make_workflow(self) -> CompiledStateGraph:
         workflow = StateGraph(State)
 
-        # add nodes
+        # nodes
         workflow.add_node("expand_topic", expand_topic)
         workflow.add_node("form_search_queries", form_search_queries)
         workflow.add_node("search", search)
+        workflow.add_node("filter_relevance", filter_relevance)
+        workflow.add_node("evaluate_quality", evaluate_quality)
+        workflow.add_node("form_additional_queries", form_additional_queries)
+        workflow.add_node("download_and_summarize", download_and_summarize)
         workflow.add_node("compose_review", compose_review)
 
-        # add edges
+        # edges
         workflow.add_edge(START, "expand_topic")
         workflow.add_edge("expand_topic", "form_search_queries")
         workflow.add_edge("form_search_queries", "search")
-        workflow.add_edge("search", "compose_review")
+        workflow.add_edge("search", "filter_relevance")
+        workflow.add_edge("filter_relevance", "evaluate_quality")
+        workflow.add_conditional_edges(
+            "evaluate_quality",
+            _route_after_quality,
+            {"retry": "form_additional_queries", "proceed": "download_and_summarize"},
+        )
+        workflow.add_edge("form_additional_queries", "search")
+        workflow.add_edge("download_and_summarize", "compose_review")
         workflow.add_edge("compose_review", END)
 
         return workflow.compile()
@@ -130,7 +401,6 @@ class AgenticLiteratureReview:
         for chunk in self._stream():
             if chunk["type"] == "updates":
                 for node_name, state in chunk["data"].items():
-                    # print(f"Node {node_name} updated {state}")
                     yield node_name, state
 
     def _stream(self):

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -21,7 +21,7 @@ Directions:
 {% for direction in directions %}
 - {{direction}}
 {% endfor %}
-                                                  
+
 
 Your output will be used to query arXiv via the arXiv API in the `query` parameter.
 
@@ -29,9 +29,87 @@ Search queries for arXiv:
 """)
 
 
+PROMPT_RELEVANCE_FILTER = env.from_string("""
+You are evaluating research papers for a literature review. Assign a relevance label to each paper.
+
+Topic: {{topic}}
+
+Research directions:
+{% for direction in directions %}
+- {{direction}}
+{% endfor %}
+
+Relevance labels:
+- NOT_REL: not relevant to the topic and research directions at all
+- REL-: tangentially related but provides little direct value for this literature review
+- REL: clearly relevant and useful for this literature review
+- REL+: highly relevant and significant; a key paper for this topic
+
+Papers to evaluate (use the exact paper_id in your response):
+{% for paper in papers %}
+[{{paper.paper_id}}]
+Title: {{paper.title}}
+Abstract: {{paper.abstract}}
+
+{% endfor %}
+
+Return a relevance score for EVERY paper listed above. Use the exact paper_id values shown in brackets.
+""")
+
+
+PROMPT_ADDITIONAL_QUERIES = env.from_string("""
+You are helping conduct a literature review. The current set of retrieved papers is insufficient — there are not enough highly relevant papers.
+
+Topic: {{topic}}
+
+Research directions:
+{% for direction in directions %}
+- {{direction}}
+{% endfor %}
+
+Papers found so far (with relevance grades):
+{% for paper in papers %}
+- [{{paper.relevance}}] {{paper.title}}
+{% endfor %}
+
+Search queries already used:
+{% for q in previous_queries %}
+- {{q}}
+{% endfor %}
+
+Generate 3-5 NEW search queries for arXiv that would find additional relevant papers. Focus on research directions that are underrepresented in the papers found so far. Do NOT repeat queries already used.
+
+New search queries:
+""")
+
+
+PROMPT_SUMMARIZE_PAPER = env.from_string("""
+Summarize the following research paper for use in a literature review. Extract the key information in four sections:
+
+**Problem**: What specific problem or research question does this paper address?
+**Method**: What approach, technique, or methodology is proposed or used?
+**Results**: What are the main findings, contributions, or outcomes?
+**Limitations**: What limitations, open questions, or future work are mentioned?
+
+Keep each section to 2-3 concise, precise sentences. Use technical language appropriate for an academic audience.
+
+Paper title: {{title}}
+
+{% if full_text %}
+Full paper text (excerpt):
+{{full_text}}
+{% else %}
+Abstract:
+{{abstract}}
+{% endif %}
+
+Summary:
+""")
+
+
 PROMPT_COMPOSE_REVIEW = env.from_string("""
 User wants to make a literature review of a certain topic. Your task is to compose a review of the literature for a given topic, relevant research directions, and found papers.
-                                        
+
 Structure your review in a Markdown format. You need to cover the following aspects:
 - Research directions
 - Key papers
@@ -48,19 +126,18 @@ Topic: {{topic}}
 - {{direction}}
 {% endfor %}
 
-## Search results
+## Papers
 
 {% for result in search_results %}
 ### {{result.title}}
 
 Authors: {{result.authors}}
 
-Abstract:
-{{result.abstract}}
+Relevance: {{result.relevance}}
 
 Summary:
 {{result.summary}}
-                               
+
 DOI: {{result.doi}}
 
 Citation: {{result.citation}}

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -11,6 +11,8 @@ class PaperSearchResult(TypedDict):
     citation: str
     summary: str
     paper_id: str
+    relevance: str           # "NOT_REL" | "REL-" | "REL" | "REL+" | "" (empty = unscored)
+    completeness_score: int  # count of non-empty fields (0–7)
 
 
 class Directions(TypedDict):
@@ -21,9 +23,22 @@ class SearchQueries(TypedDict):
     search_queries: list[str]
 
 
+class PaperRelevanceScore(TypedDict):
+    paper_id: str
+    relevance: str  # one of NOT_REL, REL-, REL, REL+
+
+
+class RelevanceScores(TypedDict):
+    scores: list[PaperRelevanceScore]
+
+
 class State(TypedDict):
     topic: str
     directions: list[str] | None
     search_queries: list[str] | None
     search_results: list[PaperSearchResult] | None
     review: str | None
+    session_id: str | None
+    search_iteration: int        # starts at 0; incremented each retry
+    quality_warning: str | None  # set when max iterations reached with insufficient papers
+    quality_ok: bool | None      # set by evaluate_quality node

--- a/src/session_store.py
+++ b/src/session_store.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -16,18 +16,27 @@ class Session:
     directions: list
     search_results: list
     review: str
+    quality_warning: str | None = field(default=None)
 
 
-def make_session(topic: str, directions: list, search_results: list, review: str) -> Session:
+def make_session(
+    topic: str,
+    directions: list,
+    search_results: list,
+    review: str,
+    session_id: str | None = None,
+    quality_warning: str | None = None,
+) -> Session:
     name = topic[:50].strip() + ("..." if len(topic) > 50 else "")
     return Session(
-        id=str(uuid.uuid4()),
+        id=session_id or str(uuid.uuid4()),
         name=name,
         topic=topic,
         created_at=datetime.now().isoformat(),
         directions=directions,
         search_results=list(search_results),
         review=review,
+        quality_warning=quality_warning,
     )
 
 

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,0 +1,64 @@
+import re
+from logging import getLogger
+from pathlib import Path
+from time import sleep
+
+import requests
+
+logger = getLogger(__name__)
+
+_ARXIV_VERSION_RE = re.compile(r"v\d+$")
+
+
+def download_arxiv_pdf(arxiv_id: str, dest_path: Path) -> bool:
+    """Download a PDF from arxiv.org for the given arXiv ID.
+
+    Strips any version suffix (e.g. '2301.12345v2' → '2301.12345') so the
+    latest version is always fetched.  Returns True on success.
+    """
+    base_id = _ARXIV_VERSION_RE.sub("", arxiv_id)
+    url = f"https://arxiv.org/pdf/{base_id}"
+    try:
+        sleep(0.5)  # polite delay
+        resp = requests.get(url, timeout=30, stream=True)
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "")
+        if "pdf" not in content_type and "octet-stream" not in content_type:
+            logger.warning("Unexpected content-type for %s PDF: %s", arxiv_id, content_type)
+            return False
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with dest_path.open("wb") as f:
+            for chunk in resp.iter_content(chunk_size=65536):
+                f.write(chunk)
+        logger.info("Downloaded PDF for %s → %s", arxiv_id, dest_path)
+        return True
+    except requests.RequestException as e:
+        logger.warning("PDF download failed for %s: %s", arxiv_id, e)
+        return False
+
+
+def extract_pdf_text(pdf_path: Path, max_chars: int = 64000) -> str:
+    """Extract plain text from a PDF file using pypdf.
+
+    Returns up to *max_chars* characters concatenated from all pages.
+    Returns an empty string if the file cannot be read.
+    """
+    try:
+        from pypdf import PdfReader  # local import to keep startup fast if pypdf is missing
+
+        reader = PdfReader(str(pdf_path))
+        parts: list[str] = []
+        total = 0
+        for page in reader.pages:
+            text = page.extract_text() or ""
+            remaining = max_chars - total
+            if remaining <= 0:
+                break
+            parts.append(text[:remaining])
+            total += len(text)
+            if total >= max_chars:
+                break
+        return "".join(parts)
+    except Exception as e:
+        logger.warning("PDF text extraction failed for %s: %s", pdf_path, e)
+        return ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.fixture
+def sample_paper():
+    """A fully-populated PaperSearchResult dict."""
+    return {
+        "title": "Test Paper on Transformers",
+        "authors": "Alice Smith, Bob Jones",
+        "published_date": "2024-01-15",
+        "abstract": "We study attention mechanisms in large language models.",
+        "doi": "10.1234/test.2024",
+        "url": "https://arxiv.org/abs/2401.00001",
+        "citation": "@article{Smith2024, title={Test Paper}, year={2024}}",
+        "summary": "",
+        "paper_id": "2401.00001",
+        "relevance": "",
+        "completeness_score": 0,
+    }
+
+
+@pytest.fixture
+def sessions_dir(tmp_path, monkeypatch):
+    """Redirect session_store.SESSIONS_DIR to a temporary directory."""
+    import src.session_store as ss
+
+    target = tmp_path / "sessions"
+    monkeypatch.setattr(ss, "SESSIONS_DIR", target)
+    return target

--- a/tests/test_agentic_workflow.py
+++ b/tests/test_agentic_workflow.py
@@ -1,0 +1,490 @@
+"""Tests for pure logic in src/agentic_workflow.py — no real LLM or network calls."""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Set dummy env vars so module-level code in agentic_workflow doesn't error
+os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
+os.environ.setdefault("OPENROUTER_MODEL", "test-model")
+
+from src.agentic_workflow import (
+    NoRelevantPapersFound,
+    _compute_completeness,
+    _invoke_with_retry,
+    _is_transient,
+    _route_after_quality,
+    _tls,
+    evaluate_quality,
+    filter_relevance,
+    search,
+    set_search_progress_callback,
+    set_summarize_progress_callback,
+)
+
+
+# ---------------------------------------------------------------------------
+# _compute_completeness
+# ---------------------------------------------------------------------------
+
+
+def test_completeness_all_fields_populated():
+    paper = {
+        "title": "A",
+        "authors": "B",
+        "abstract": "C",
+        "doi": "D",
+        "url": "E",
+        "citation": "F",
+        "published_date": "G",
+    }
+    assert _compute_completeness(paper) == 7
+
+
+def test_completeness_none_values_not_counted():
+    paper = {
+        "title": "A",
+        "authors": None,
+        "abstract": None,
+        "doi": None,
+        "url": "E",
+        "citation": None,
+        "published_date": None,
+    }
+    assert _compute_completeness(paper) == 2
+
+
+def test_completeness_empty_strings_not_counted():
+    paper = {
+        "title": "A",
+        "authors": "",
+        "abstract": "",
+        "doi": "",
+        "url": "",
+        "citation": "",
+        "published_date": "",
+    }
+    assert _compute_completeness(paper) == 1
+
+
+def test_completeness_whitespace_not_counted():
+    paper = {
+        "title": "  ",
+        "authors": "\t",
+        "abstract": "actual content",
+        "doi": "",
+        "url": "",
+        "citation": "",
+        "published_date": "",
+    }
+    assert _compute_completeness(paper) == 1
+
+
+def test_completeness_partial():
+    paper = {
+        "title": "Title",
+        "authors": "Author",
+        "abstract": "Abstract",
+        "doi": "",
+        "url": "",
+        "citation": "",
+        "published_date": "",
+    }
+    assert _compute_completeness(paper) == 3
+
+
+def test_completeness_missing_keys_treated_as_empty():
+    paper = {"title": "Only title"}
+    assert _compute_completeness(paper) == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_transient
+# ---------------------------------------------------------------------------
+
+
+def _exc(name: str) -> Exception:
+    """Create an exception whose class name matches *name*."""
+    cls = type(name, (Exception,), {})
+    return cls("test error")
+
+
+def test_is_transient_remote_protocol_error():
+    assert _is_transient(_exc("RemoteProtocolError")) is True
+
+
+def test_is_transient_read_timeout():
+    assert _is_transient(_exc("ReadTimeout")) is True
+
+
+def test_is_transient_connect_error():
+    assert _is_transient(_exc("ConnectError")) is True
+
+
+def test_is_transient_incomplete_read():
+    assert _is_transient(_exc("IncompleteRead")) is True
+
+
+def test_is_transient_chunked_encoding_error():
+    assert _is_transient(_exc("ChunkedEncodingError")) is True
+
+
+def test_is_transient_value_error():
+    assert _is_transient(ValueError("bad input")) is False
+
+
+def test_is_transient_key_error():
+    assert _is_transient(KeyError("missing")) is False
+
+
+def test_is_transient_runtime_error():
+    assert _is_transient(RuntimeError("oops")) is False
+
+
+# ---------------------------------------------------------------------------
+# _route_after_quality
+# ---------------------------------------------------------------------------
+
+
+def test_route_returns_retry_when_not_ok():
+    assert _route_after_quality({"quality_ok": False}) == "retry"
+
+
+def test_route_returns_proceed_when_ok():
+    assert _route_after_quality({"quality_ok": True}) == "proceed"
+
+
+def test_route_returns_retry_when_none():
+    assert _route_after_quality({"quality_ok": None}) == "retry"
+
+
+def test_route_returns_retry_when_key_missing():
+    assert _route_after_quality({}) == "retry"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_quality
+# ---------------------------------------------------------------------------
+
+
+def _make_paper(relevance: str) -> dict:
+    return {
+        "title": "T",
+        "authors": "A",
+        "abstract": "",
+        "doi": "",
+        "url": "",
+        "citation": "",
+        "summary": "",
+        "paper_id": "p1",
+        "published_date": "",
+        "relevance": relevance,
+        "completeness_score": 5,
+    }
+
+
+def test_quality_passes_when_enough_rel_papers(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 3)
+    papers = [_make_paper("REL"), _make_paper("REL"), _make_paper("REL")]
+    state = {"search_results": papers, "search_iteration": 0}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is True
+    assert result.get("quality_warning") is None
+
+
+def test_quality_passes_counting_rel_plus(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 2)
+    papers = [_make_paper("REL+"), _make_paper("REL+")]
+    state = {"search_results": papers, "search_iteration": 0}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is True
+
+
+def test_quality_fails_first_iteration(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 3)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    papers = [_make_paper("REL")]
+    state = {"search_results": papers, "search_iteration": 0}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is False
+    assert result["search_iteration"] == 1
+
+
+def test_quality_increments_iteration(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 5)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    papers = [_make_paper("REL")]
+    state = {"search_results": papers, "search_iteration": 1}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is False
+    assert result["search_iteration"] == 2
+
+
+def test_quality_accepts_with_warning_at_max_iter(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 5)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    papers = [_make_paper("REL")]
+    state = {"search_results": papers, "search_iteration": 3}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is True
+    assert result["quality_warning"] is not None
+    assert "1" in result["quality_warning"]  # mentions count
+
+
+def test_quality_raises_no_papers_at_max_iter(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 3)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    state = {"search_results": [], "search_iteration": 3}
+    with pytest.raises(NoRelevantPapersFound):
+        evaluate_quality(state)
+
+
+def test_quality_does_not_raise_no_papers_below_max(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 3)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    state = {"search_results": [], "search_iteration": 1}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is False
+
+
+def test_quality_rel_minus_not_counted(monkeypatch):
+    monkeypatch.setattr("src.agentic_workflow.MIN_REL_PAPERS", 2)
+    monkeypatch.setattr("src.agentic_workflow.MAX_SEARCH_ITERATIONS", 3)
+    # Only REL- papers — should not pass quality check
+    papers = [_make_paper("REL-"), _make_paper("REL-"), _make_paper("REL-")]
+    state = {"search_results": papers, "search_iteration": 0}
+    result = evaluate_quality(state)
+    assert result["quality_ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# filter_relevance (mock get_llm)
+# ---------------------------------------------------------------------------
+
+
+def _full_paper(paper_id: str, **overrides) -> dict:
+    base = {
+        "title": "Title",
+        "authors": "Author",
+        "abstract": "Abstract text",
+        "doi": "10.1234/x",
+        "url": "https://example.com",
+        "citation": "@article{}",
+        "summary": "",
+        "paper_id": paper_id,
+        "published_date": "2024-01-01",
+        "relevance": "",
+        "completeness_score": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _sparse_paper(paper_id: str) -> dict:
+    """Paper with only title — completeness_score will be 1 after filtering."""
+    return {
+        "title": "Sparse Paper",
+        "authors": "",
+        "abstract": "",
+        "doi": "",
+        "url": "",
+        "citation": "",
+        "summary": "",
+        "paper_id": paper_id,
+        "published_date": "",
+        "relevance": "",
+        "completeness_score": 0,
+    }
+
+
+def _mock_llm(mocker, scores: list[dict]):
+    """Patch get_llm() to return a mock that yields the given scores."""
+    mock_llm_instance = MagicMock()
+    mock_llm_instance.with_structured_output.return_value.invoke.return_value = {
+        "scores": scores
+    }
+    mocker.patch("src.agentic_workflow.get_llm", return_value=mock_llm_instance)
+    return mock_llm_instance
+
+
+def test_filter_empty_input_returns_empty_without_llm_call(mocker):
+    mock_get_llm = mocker.patch("src.agentic_workflow.get_llm")
+    state = {"topic": "t", "directions": [], "search_results": []}
+    result = filter_relevance(state)
+    assert result["search_results"] == []
+    mock_get_llm.assert_not_called()
+
+
+def test_filter_removes_not_rel(mocker):
+    papers = [
+        _full_paper("p1"),
+        _full_paper("p2"),
+    ]
+    _mock_llm(mocker, [
+        {"paper_id": "p1", "relevance": "REL"},
+        {"paper_id": "p2", "relevance": "NOT_REL"},
+    ])
+    state = {"topic": "t", "directions": [], "search_results": papers}
+    result = filter_relevance(state)
+    ids = [p["paper_id"] for p in result["search_results"]]
+    assert "p1" in ids
+    assert "p2" not in ids
+
+
+def test_filter_keeps_good_rel_minus(mocker):
+    """REL- paper with completeness >= 3 should be kept."""
+    papers = [_full_paper("p1"), _full_paper("p2")]
+    _mock_llm(mocker, [
+        {"paper_id": "p1", "relevance": "REL+"},
+        {"paper_id": "p2", "relevance": "REL-"},
+    ])
+    state = {"topic": "t", "directions": [], "search_results": papers}
+    result = filter_relevance(state)
+    ids = [p["paper_id"] for p in result["search_results"]]
+    # p2 is REL- but has completeness 7 (all fields populated) → kept
+    assert "p2" in ids
+
+
+def test_filter_removes_bad_completeness_rel_minus(mocker):
+    """REL- paper with completeness < 3 is removed when other papers remain."""
+    papers = [
+        _full_paper("p1"),           # REL, completeness 7 → kept
+        _sparse_paper("p2"),         # REL-, completeness 1 → removed
+    ]
+    _mock_llm(mocker, [
+        {"paper_id": "p1", "relevance": "REL"},
+        {"paper_id": "p2", "relevance": "REL-"},
+    ])
+    state = {"topic": "t", "directions": [], "search_results": papers}
+    result = filter_relevance(state)
+    ids = [p["paper_id"] for p in result["search_results"]]
+    assert "p1" in ids
+    assert "p2" not in ids
+
+
+def test_filter_keeps_bad_rel_minus_if_only_paper(mocker):
+    """If the only paper is REL- with low completeness, keep it anyway."""
+    papers = [_sparse_paper("p1")]
+    _mock_llm(mocker, [{"paper_id": "p1", "relevance": "REL-"}])
+    state = {"topic": "t", "directions": [], "search_results": papers}
+    result = filter_relevance(state)
+    assert len(result["search_results"]) == 1
+
+
+def test_filter_defaults_missing_score_to_rel_minus(mocker):
+    """If LLM omits a paper from scores, default to REL-."""
+    papers = [_full_paper("p1"), _full_paper("p2")]
+    _mock_llm(mocker, [
+        {"paper_id": "p1", "relevance": "REL"},
+        # p2 missing from scores
+    ])
+    state = {"topic": "t", "directions": [], "search_results": papers}
+    result = filter_relevance(state)
+    p2 = next((p for p in result["search_results"] if p["paper_id"] == "p2"), None)
+    assert p2 is not None
+    assert p2["relevance"] == "REL-"
+
+
+# ---------------------------------------------------------------------------
+# _invoke_with_retry
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_succeeds_on_first_try():
+    mock_llm = MagicMock()
+    mock_llm.invoke.return_value = MagicMock(content="response")
+    result = _invoke_with_retry(mock_llm, "prompt", max_retries=3)
+    assert mock_llm.invoke.call_count == 1
+
+
+def test_invoke_retries_on_transient_error(mocker):
+    transient_cls = type("RemoteProtocolError", (Exception,), {})
+    mock_llm = MagicMock()
+    good_response = MagicMock(content="ok")
+    mock_llm.invoke.side_effect = [transient_cls("drop"), good_response]
+    mocker.patch("src.agentic_workflow.time.sleep")  # skip backoff
+
+    result = _invoke_with_retry(mock_llm, "prompt", max_retries=3)
+
+    assert mock_llm.invoke.call_count == 2
+    assert result.content == "ok"
+
+
+def test_invoke_raises_after_max_retries(mocker):
+    transient_cls = type("RemoteProtocolError", (Exception,), {})
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = transient_cls("always fails")
+    mocker.patch("src.agentic_workflow.time.sleep")
+
+    with pytest.raises(Exception, match="always fails"):
+        _invoke_with_retry(mock_llm, "prompt", max_retries=3)
+
+    assert mock_llm.invoke.call_count == 3
+
+
+def test_invoke_does_not_retry_non_transient():
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = ValueError("bad prompt")
+
+    with pytest.raises(ValueError, match="bad prompt"):
+        _invoke_with_retry(mock_llm, "prompt", max_retries=3)
+
+    assert mock_llm.invoke.call_count == 1  # no retry
+
+
+# ---------------------------------------------------------------------------
+# Progress callbacks
+# ---------------------------------------------------------------------------
+
+
+def test_set_search_progress_callback_stores_and_clears():
+    calls = []
+    set_search_progress_callback(lambda c, t, q: calls.append((c, t, q)))
+    cb = getattr(_tls, "on_search_progress", None)
+    assert cb is not None
+    cb(1, 5, "test query")
+    assert calls == [(1, 5, "test query")]
+    set_search_progress_callback(None)
+    assert getattr(_tls, "on_search_progress", None) is None
+
+
+def test_set_summarize_progress_callback_stores_and_clears():
+    calls = []
+    set_summarize_progress_callback(lambda c, t, ti: calls.append((c, t, ti)))
+    cb = getattr(_tls, "on_summarize_progress", None)
+    assert cb is not None
+    cb(3, 7, "Some Paper Title")
+    assert calls == [(3, 7, "Some Paper Title")]
+    set_summarize_progress_callback(None)
+    assert getattr(_tls, "on_summarize_progress", None) is None
+
+
+def test_search_node_calls_progress_callback(mocker):
+    """search() should call the progress callback once per query."""
+    calls = []
+    set_search_progress_callback(lambda c, t, q: calls.append((c, t, q)))
+
+    mock_engine = mocker.patch("src.agentic_workflow.SEARCH_ENGINE")
+    mock_engine.search.return_value = []  # no results to avoid schema issues
+
+    try:
+        state = {
+            "search_queries": ["query one", "query two"],
+            "search_results": None,
+        }
+        search(state)
+    finally:
+        set_search_progress_callback(None)
+
+    assert len(calls) == 2
+    assert calls[0] == (1, 2, "query one")
+    assert calls[1] == (2, 2, "query two")
+
+
+def test_search_node_works_without_callback(mocker):
+    """search() must not raise when no progress callback is registered."""
+    set_search_progress_callback(None)
+    mock_engine = mocker.patch("src.agentic_workflow.SEARCH_ENGINE")
+    mock_engine.search.return_value = []
+    state = {"search_queries": ["q"], "search_results": None}
+    search(state)  # should not raise

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,209 @@
+"""Tests that all Jinja2 prompt templates render without error and contain expected content."""
+
+import pytest
+
+from src.prompts import (
+    PROMPT_ADDITIONAL_QUERIES,
+    PROMPT_COMPOSE_REVIEW,
+    PROMPT_CONSTRUCT_SEARCH_QUERIES,
+    PROMPT_EXPAND_TOPIC,
+    PROMPT_RELEVANCE_FILTER,
+    PROMPT_SUMMARIZE_PAPER,
+)
+
+
+@pytest.fixture
+def papers():
+    return [
+        {
+            "paper_id": "2401.00001",
+            "title": "Attention Is All You Need",
+            "abstract": "We propose the Transformer architecture.",
+            "relevance": "REL+",
+            "summary": "Problem: seq2seq. Method: attention. Results: SOTA.",
+            "authors": "Vaswani et al.",
+            "published_date": "2017-06-12",
+            "doi": "10.48550/arXiv.1706.03762",
+            "url": "https://arxiv.org/abs/1706.03762",
+            "citation": "@article{vaswani2017}",
+            "completeness_score": 7,
+        },
+        {
+            "paper_id": "openalex:W9876",
+            "title": "BERT: Pre-training of Deep Bidirectional Transformers",
+            "abstract": "We introduce BERT.",
+            "relevance": "REL",
+            "summary": "Problem: NLP pre-training. Method: masked LM. Results: GLUE SOTA.",
+            "authors": "Devlin et al.",
+            "published_date": "2019-05-24",
+            "doi": "",
+            "url": "https://arxiv.org/abs/1810.04805",
+            "citation": "",
+            "completeness_score": 5,
+        },
+    ]
+
+
+@pytest.fixture
+def directions():
+    return ["Self-attention mechanisms", "Pre-training strategies"]
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_EXPAND_TOPIC
+# ---------------------------------------------------------------------------
+
+
+def test_expand_topic_renders(directions):
+    rendered = PROMPT_EXPAND_TOPIC.render(topic="Large language models")
+    assert "Large language models" in rendered
+    assert len(rendered) > 10
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_CONSTRUCT_SEARCH_QUERIES
+# ---------------------------------------------------------------------------
+
+
+def test_construct_search_queries_renders(directions):
+    rendered = PROMPT_CONSTRUCT_SEARCH_QUERIES.render(
+        topic="Transformer architectures",
+        directions=directions,
+    )
+    assert "Transformer architectures" in rendered
+    assert "Self-attention" in rendered
+    assert "Pre-training" in rendered
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_RELEVANCE_FILTER
+# ---------------------------------------------------------------------------
+
+
+def test_relevance_filter_renders_topic_and_directions(papers, directions):
+    rendered = PROMPT_RELEVANCE_FILTER.render(
+        topic="Deep learning for NLP",
+        directions=directions,
+        papers=papers,
+    )
+    assert "Deep learning for NLP" in rendered
+    assert "Self-attention" in rendered
+
+
+def test_relevance_filter_renders_all_paper_ids(papers, directions):
+    rendered = PROMPT_RELEVANCE_FILTER.render(
+        topic="NLP",
+        directions=directions,
+        papers=papers,
+    )
+    assert "2401.00001" in rendered
+    assert "openalex:W9876" in rendered
+
+
+def test_relevance_filter_renders_relevance_labels_explanation(papers, directions):
+    rendered = PROMPT_RELEVANCE_FILTER.render(
+        topic="NLP",
+        directions=directions,
+        papers=papers,
+    )
+    assert "NOT_REL" in rendered
+    assert "REL+" in rendered
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_SUMMARIZE_PAPER
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_with_full_text_uses_full_text_block():
+    rendered = PROMPT_SUMMARIZE_PAPER.render(
+        title="My Paper",
+        full_text="Introduction: We study X. Method: We use Y. Results: Z.",
+        abstract="Short abstract.",
+    )
+    assert "My Paper" in rendered
+    assert "Introduction" in rendered
+
+
+def test_summarize_without_full_text_uses_abstract():
+    rendered = PROMPT_SUMMARIZE_PAPER.render(
+        title="My Paper",
+        full_text=None,
+        abstract="Short abstract about transformers.",
+    )
+    assert "My Paper" in rendered
+    assert "Short abstract about transformers" in rendered
+
+
+def test_summarize_requests_structured_sections():
+    rendered = PROMPT_SUMMARIZE_PAPER.render(
+        title="Paper",
+        full_text=None,
+        abstract="abstract",
+    )
+    assert "Problem" in rendered
+    assert "Method" in rendered
+    assert "Results" in rendered
+    assert "Limitations" in rendered
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_ADDITIONAL_QUERIES
+# ---------------------------------------------------------------------------
+
+
+def test_additional_queries_renders_previous_queries(papers, directions):
+    rendered = PROMPT_ADDITIONAL_QUERIES.render(
+        topic="NLP",
+        directions=directions,
+        papers=papers,
+        previous_queries=["transformers attention", "BERT pre-training"],
+    )
+    assert "transformers attention" in rendered
+    assert "BERT pre-training" in rendered
+
+
+def test_additional_queries_renders_paper_relevance(papers, directions):
+    rendered = PROMPT_ADDITIONAL_QUERIES.render(
+        topic="NLP",
+        directions=directions,
+        papers=papers,
+        previous_queries=[],
+    )
+    assert "REL+" in rendered
+    assert "Attention Is All You Need" in rendered
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_COMPOSE_REVIEW
+# ---------------------------------------------------------------------------
+
+
+def test_compose_review_renders_papers(papers, directions):
+    rendered = PROMPT_COMPOSE_REVIEW.render(
+        topic="Transformer models",
+        directions=directions,
+        search_results=papers,
+    )
+    assert "Transformer models" in rendered
+    assert "Attention Is All You Need" in rendered
+    assert "BERT" in rendered
+
+
+def test_compose_review_renders_summaries(papers, directions):
+    rendered = PROMPT_COMPOSE_REVIEW.render(
+        topic="NLP",
+        directions=directions,
+        search_results=papers,
+    )
+    assert "Problem: seq2seq" in rendered
+
+
+def test_compose_review_renders_review_tags(papers, directions):
+    rendered = PROMPT_COMPOSE_REVIEW.render(
+        topic="NLP",
+        directions=directions,
+        search_results=papers,
+    )
+    assert "<review>" in rendered
+    assert "</review>" in rendered

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,0 +1,152 @@
+import pytest
+
+from src.search_engine import _build_minimal_bibtex, _dedup_accept, _normalize_arxiv_id
+from src.schemas import PaperSearchResult
+
+
+# ---------------------------------------------------------------------------
+# _normalize_arxiv_id
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_strips_version():
+    assert _normalize_arxiv_id("2301.12345v2") == "2301.12345"
+
+
+def test_normalize_strips_version_v1():
+    assert _normalize_arxiv_id("2301.12345v1") == "2301.12345"
+
+
+def test_normalize_no_version_unchanged():
+    assert _normalize_arxiv_id("2301.12345") == "2301.12345"
+
+
+def test_normalize_old_hep_format():
+    assert _normalize_arxiv_id("hep-th/9901001v1") == "hep-th/9901001"
+
+
+def test_normalize_old_format_no_version():
+    assert _normalize_arxiv_id("hep-th/9901001") == "hep-th/9901001"
+
+
+# ---------------------------------------------------------------------------
+# _dedup_accept helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_paper(paper_id: str, doi: str = "") -> PaperSearchResult:
+    return PaperSearchResult(
+        title="T",
+        authors="A",
+        published_date="2024-01-01",
+        abstract="",
+        doi=doi,
+        url="",
+        citation="",
+        summary="",
+        paper_id=paper_id,
+        relevance="",
+        completeness_score=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _dedup_accept
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_accept_new_doi():
+    seen_dois: set = set()
+    seen_arxiv: set = set()
+    paper = _make_paper("openalex:W1", doi="10.1234/abc")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is True
+    assert "10.1234/abc" in seen_dois
+
+
+def test_dedup_accept_duplicate_doi():
+    seen_dois = {"10.1234/abc"}
+    seen_arxiv: set = set()
+    paper = _make_paper("openalex:W2", doi="10.1234/abc")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is False
+
+
+def test_dedup_accept_doi_case_insensitive():
+    seen_dois = {"10.1234/abc"}
+    seen_arxiv: set = set()
+    paper = _make_paper("openalex:W3", doi="10.1234/ABC")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is False
+
+
+def test_dedup_accept_new_arxiv_id():
+    seen_dois: set = set()
+    seen_arxiv: set = set()
+    paper = _make_paper("2301.12345v1")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is True
+    assert "2301.12345" in seen_arxiv
+
+
+def test_dedup_accept_duplicate_arxiv_different_version():
+    seen_dois: set = set()
+    seen_arxiv = {"2301.12345"}
+    paper = _make_paper("2301.12345v2")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is False
+
+
+def test_dedup_accept_openalex_prefix_not_treated_as_arxiv():
+    seen_dois: set = set()
+    seen_arxiv: set = set()
+    paper1 = _make_paper("openalex:W111")
+    paper2 = _make_paper("openalex:W222")
+    assert _dedup_accept(paper1, seen_dois, seen_arxiv) is True
+    # second openalex paper with different id is also accepted (no arxiv overlap)
+    assert _dedup_accept(paper2, seen_dois, seen_arxiv) is True
+    assert len(seen_arxiv) == 0  # nothing added to arxiv set
+
+
+def test_dedup_accept_no_doi_no_arxiv_accepted():
+    seen_dois: set = set()
+    seen_arxiv: set = set()
+    paper = _make_paper("openalex:W999", doi="")
+    assert _dedup_accept(paper, seen_dois, seen_arxiv) is True
+
+
+# ---------------------------------------------------------------------------
+# _build_minimal_bibtex
+# ---------------------------------------------------------------------------
+
+
+def _make_openalex_item(display_name="Test Paper", year=2024, authors=None, doi="10.99/test"):
+    item = {
+        "display_name": display_name,
+        "publication_year": year,
+        "authorships": authors or [],
+    }
+    return item
+
+
+def test_build_minimal_bibtex_with_author_and_year():
+    item = _make_openalex_item(
+        authors=[{"author": {"display_name": "Jane Doe"}}],
+        year=2023,
+    )
+    result = _build_minimal_bibtex(item, "10.1234/x")
+    assert "Doe2023" in result
+    assert "2023" in result
+
+
+def test_build_minimal_bibtex_no_authors_uses_openalex_key():
+    item = _make_openalex_item(authors=[], year=2021)
+    result = _build_minimal_bibtex(item, "10.1234/x")
+    assert "openalex2021" in result
+
+
+def test_build_minimal_bibtex_contains_doi():
+    item = _make_openalex_item(doi="10.9999/mypaper")
+    result = _build_minimal_bibtex(item, "10.9999/mypaper")
+    assert "10.9999/mypaper" in result
+
+
+def test_build_minimal_bibtex_contains_title():
+    item = _make_openalex_item(display_name="My Great Paper")
+    result = _build_minimal_bibtex(item, "10.1234/x")
+    assert "My Great Paper" in result

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,0 +1,158 @@
+import json
+import time
+import uuid
+
+import pytest
+
+from src.session_store import (
+    Session,
+    delete_session,
+    list_sessions,
+    load_session,
+    make_session,
+    save_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# make_session
+# ---------------------------------------------------------------------------
+
+
+def test_make_session_generates_uuid():
+    s = make_session("topic", [], [], "review")
+    uuid.UUID(s.id)  # raises if not valid UUID
+
+
+def test_make_session_uses_provided_id():
+    sid = str(uuid.uuid4())
+    s = make_session("topic", [], [], "review", session_id=sid)
+    assert s.id == sid
+
+
+def test_make_session_truncates_name_at_50():
+    long_topic = "A" * 60
+    s = make_session(long_topic, [], [], "review")
+    assert s.name.endswith("...")
+    assert len(s.name) <= 53  # 50 chars + "..."
+
+
+def test_make_session_short_name_no_ellipsis():
+    s = make_session("Short topic", [], [], "review")
+    assert "..." not in s.name
+    assert s.name == "Short topic"
+
+
+def test_make_session_quality_warning_stored():
+    s = make_session("topic", [], [], "review", quality_warning="Low quality")
+    assert s.quality_warning == "Low quality"
+
+
+def test_make_session_quality_warning_defaults_to_none():
+    s = make_session("topic", [], [], "review")
+    assert s.quality_warning is None
+
+
+# ---------------------------------------------------------------------------
+# save / load roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_roundtrip(sessions_dir):
+    s = make_session(
+        "My research topic",
+        ["dir1", "dir2"],
+        [{"title": "Paper", "paper_id": "123", "relevance": "REL"}],
+        "## Review content",
+        session_id="test-id-123",
+        quality_warning="some warning",
+    )
+    save_session(s)
+    loaded = load_session("test-id-123")
+    assert loaded.id == s.id
+    assert loaded.topic == s.topic
+    assert loaded.directions == s.directions
+    assert loaded.review == s.review
+    assert loaded.quality_warning == s.quality_warning
+    assert len(loaded.search_results) == 1
+
+
+def test_save_load_roundtrip_no_quality_warning(sessions_dir):
+    s = make_session("topic", [], [], "review", session_id="no-warn-id")
+    save_session(s)
+    loaded = load_session("no-warn-id")
+    assert loaded.quality_warning is None
+
+
+def test_load_session_legacy_json_without_quality_warning(sessions_dir, tmp_path):
+    """Sessions saved before quality_warning was added should still load."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "id": "legacy-id",
+        "name": "old session",
+        "topic": "something",
+        "created_at": "2024-01-01T00:00:00",
+        "directions": [],
+        "search_results": [],
+        "review": "old review",
+        # no quality_warning key
+    }
+    (sessions_dir / "legacy-id.json").write_text(json.dumps(legacy))
+    loaded = load_session("legacy-id")
+    assert loaded.id == "legacy-id"
+    assert loaded.quality_warning is None
+
+
+# ---------------------------------------------------------------------------
+# list_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_list_sessions_empty_when_no_dir(sessions_dir):
+    # sessions_dir fixture sets the path but doesn't create it
+    result = list_sessions()
+    assert result == []
+
+
+def test_list_sessions_returns_sessions(sessions_dir):
+    s1 = make_session("topic 1", [], [], "r1", session_id="id-1")
+    s2 = make_session("topic 2", [], [], "r2", session_id="id-2")
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    save_session(s1)
+    time.sleep(0.01)  # ensure mtime differs
+    save_session(s2)
+
+    result = list_sessions()
+    assert len(result) == 2
+    # newest first
+    assert result[0].id == "id-2"
+    assert result[1].id == "id-1"
+
+
+def test_list_sessions_skips_malformed_json(sessions_dir):
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / "bad.json").write_text("not json {{{")
+    s = make_session("good topic", [], [], "review", session_id="good-id")
+    save_session(s)
+
+    result = list_sessions()
+    assert len(result) == 1
+    assert result[0].id == "good-id"
+
+
+# ---------------------------------------------------------------------------
+# delete_session
+# ---------------------------------------------------------------------------
+
+
+def test_delete_session_removes_file(sessions_dir):
+    s = make_session("topic", [], [], "review", session_id="del-id")
+    save_session(s)
+    assert (sessions_dir / "del-id.json").exists()
+    delete_session("del-id")
+    assert not (sessions_dir / "del-id.json").exists()
+
+
+def test_delete_session_nonexistent_does_not_raise(sessions_dir):
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    delete_session("nonexistent-id")  # should not raise

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,192 @@
+import io
+from pathlib import Path
+
+import pytest
+import requests
+
+from src.tools import download_arxiv_pdf, extract_pdf_text
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_pdf_response(mocker, content_type="application/pdf"):
+    """Build a mock requests.Response that streams fake PDF bytes."""
+    pdf_bytes = _minimal_pdf_bytes()
+    mock_resp = mocker.MagicMock()
+    mock_resp.headers = {"content-type": content_type}
+    mock_resp.raise_for_status = mocker.MagicMock()
+    mock_resp.iter_content = mocker.MagicMock(return_value=[pdf_bytes])
+    return mock_resp
+
+
+def _minimal_pdf_bytes() -> bytes:
+    """Create a real minimal single-page PDF with known text using pypdf."""
+    from pypdf import PdfWriter
+
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+def _pdf_with_text(text: str) -> Path:
+    """Write a single-page PDF containing *text* to a temp file and return the path."""
+    # We use reportlab if available, else fall back to a pre-built PDF fixture.
+    # Since reportlab may not be installed, build a raw minimal PDF manually.
+    # pypdf's PdfWriter doesn't easily add text — use a hand-crafted PDF stream.
+    from pypdf import PdfWriter, PageObject
+    import pypdf.generic as pdf_gen
+
+    writer = PdfWriter()
+    # A blank page won't have extractable text; encode text via content stream
+    # Use raw PDF syntax for a simple text page
+    raw_pdf = _raw_pdf_with_text(text)
+    buf = io.BytesIO(raw_pdf)
+    return buf  # caller reads via pypdf
+
+
+def _raw_pdf_with_text(text: str) -> bytes:
+    """Generate a minimal valid PDF (1 page) containing *text* as a text object."""
+    safe = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = f"BT /F1 12 Tf 72 720 Td ({safe}) Tj ET".encode()
+    stream_len = len(stream)
+
+    content = (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]"
+        b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+        + f"4 0 obj\n<< /Length {stream_len} >>\nstream\n".encode()
+        + stream
+        + b"\nendstream\nendobj\n"
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+    )
+    # xref + trailer
+    xref_pos = len(content)
+    content += (
+        b"xref\n0 6\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"0000000266 00000 n \n"
+        b"0000000300 00000 n \n"
+        + f"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n".encode()
+    )
+    return content
+
+
+# ---------------------------------------------------------------------------
+# download_arxiv_pdf
+# ---------------------------------------------------------------------------
+
+
+def test_download_success_writes_file(tmp_path, mocker):
+    mocker.patch("src.tools.sleep")
+    mock_resp = _make_mock_pdf_response(mocker)
+    mocker.patch("src.tools.requests.get", return_value=mock_resp)
+
+    dest = tmp_path / "2301.12345.pdf"
+    result = download_arxiv_pdf("2301.12345", dest)
+
+    assert result is True
+    assert dest.exists()
+
+
+def test_download_strips_version_in_url(tmp_path, mocker):
+    mocker.patch("src.tools.sleep")
+    mock_get = mocker.patch("src.tools.requests.get", return_value=_make_mock_pdf_response(mocker))
+
+    download_arxiv_pdf("2301.12345v3", tmp_path / "out.pdf")
+
+    called_url = mock_get.call_args[0][0]
+    assert "2301.12345" in called_url
+    assert "v3" not in called_url
+
+
+def test_download_http_error_returns_false(tmp_path, mocker):
+    mocker.patch("src.tools.sleep")
+    mocker.patch("src.tools.requests.get", side_effect=requests.RequestException("timeout"))
+
+    dest = tmp_path / "out.pdf"
+    result = download_arxiv_pdf("2301.12345", dest)
+
+    assert result is False
+    assert not dest.exists()
+
+
+def test_download_wrong_content_type_returns_false(tmp_path, mocker):
+    mocker.patch("src.tools.sleep")
+    mocker.patch("src.tools.requests.get", return_value=_make_mock_pdf_response(mocker, "text/html"))
+
+    dest = tmp_path / "out.pdf"
+    result = download_arxiv_pdf("2301.12345", dest)
+
+    assert result is False
+
+
+def test_download_creates_parent_directory(tmp_path, mocker):
+    mocker.patch("src.tools.sleep")
+    mocker.patch("src.tools.requests.get", return_value=_make_mock_pdf_response(mocker))
+
+    dest = tmp_path / "subdir" / "nested" / "out.pdf"
+    result = download_arxiv_pdf("2301.12345", dest)
+
+    assert result is True
+    assert dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# extract_pdf_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_from_valid_pdf(tmp_path):
+    text = "Hello PDF world"
+    pdf_bytes = _raw_pdf_with_text(text)
+    pdf_path = tmp_path / "test.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+
+    result = extract_pdf_text(pdf_path)
+    assert "Hello" in result or result == ""  # pypdf may or may not decode Type1 fonts
+    # At minimum: no exception and returns a string
+    assert isinstance(result, str)
+
+
+def test_extract_text_truncated_at_max_chars(tmp_path):
+    # Create a PDF by writing many pages worth of content; mock pypdf instead
+    # to avoid font encoding issues with minimal PDFs
+    from unittest.mock import MagicMock, patch
+
+    long_text = "A" * 500
+    mock_page = MagicMock()
+    mock_page.extract_text.return_value = long_text
+    mock_reader = MagicMock()
+    mock_reader.pages = [mock_page]
+
+    pdf_path = tmp_path / "dummy.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 dummy")
+
+    with patch("pypdf.PdfReader", return_value=mock_reader):
+        result = extract_pdf_text(pdf_path, max_chars=100)
+
+    assert len(result) <= 100
+
+
+def test_extract_text_invalid_file_returns_empty(tmp_path):
+    bad_pdf = tmp_path / "corrupt.pdf"
+    bad_pdf.write_bytes(b"this is not a pdf")
+
+    result = extract_pdf_text(bad_pdf)
+    assert result == ""
+
+
+def test_extract_text_missing_file_returns_empty(tmp_path):
+    missing = tmp_path / "nonexistent.pdf"
+    result = extract_pdf_text(missing)
+    assert result == ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,87 @@
+import pytest
+import requests
+
+from src.utils import get_bibtex_from_doi, reconstruct_abstract
+
+
+# ---------------------------------------------------------------------------
+# reconstruct_abstract
+# ---------------------------------------------------------------------------
+
+
+def test_reconstruct_abstract_basic():
+    index = {"hello": [0], "world": [1]}
+    assert reconstruct_abstract(index) == "hello world"
+
+
+def test_reconstruct_abstract_reorders_positions():
+    # positions are out of order in the dict
+    index = {"world": [1], "hello": [0], "there": [2]}
+    assert reconstruct_abstract(index) == "hello world there"
+
+
+def test_reconstruct_abstract_duplicate_positions():
+    # one word at multiple positions
+    index = {"the": [0, 3], "cat": [1], "sat": [2]}
+    result = reconstruct_abstract(index)
+    words = result.split()
+    assert words[0] == "the"
+    assert words[1] == "cat"
+    assert words[2] == "sat"
+    assert words[3] == "the"
+
+
+def test_reconstruct_abstract_empty_dict():
+    assert reconstruct_abstract({}) == ""
+
+
+def test_reconstruct_abstract_none():
+    assert reconstruct_abstract(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# get_bibtex_from_doi
+# ---------------------------------------------------------------------------
+
+
+def test_get_bibtex_from_doi_success(mocker):
+    mock_resp = mocker.MagicMock()
+    mock_resp.text = "@article{test2024, title={Test}}"
+    mock_resp.raise_for_status = mocker.MagicMock()
+    mocker.patch("src.utils.requests.get", return_value=mock_resp)
+    mocker.patch("src.utils.sleep")  # skip the 0.1s delay
+
+    result = get_bibtex_from_doi("10.1234/test")
+    assert result == "@article{test2024, title={Test}}"
+
+
+def test_get_bibtex_from_doi_constructs_correct_url(mocker):
+    mock_resp = mocker.MagicMock()
+    mock_resp.text = "@article{}"
+    mock_resp.raise_for_status = mocker.MagicMock()
+    mock_get = mocker.patch("src.utils.requests.get", return_value=mock_resp)
+    mocker.patch("src.utils.sleep")
+
+    get_bibtex_from_doi("10.9999/xyz")
+
+    called_url = mock_get.call_args[0][0]
+    assert "10.9999/xyz" in called_url
+    assert "bibtex" in called_url
+
+
+def test_get_bibtex_from_doi_http_error(mocker):
+    mocker.patch("src.utils.requests.get", side_effect=requests.RequestException("timeout"))
+    mocker.patch("src.utils.sleep")
+
+    result = get_bibtex_from_doi("10.1234/bad")
+    assert result is None
+
+
+def test_get_bibtex_from_doi_bad_status(mocker):
+    mock_resp = mocker.MagicMock()
+    mock_resp.raise_for_status.side_effect = requests.HTTPError("404")
+    mocker.patch("src.utils.requests.get", return_value=mock_resp)
+    mocker.patch("src.utils.sleep")
+
+    result = get_bibtex_from_doi("10.1234/missing")
+    assert result is None


### PR DESCRIPTION
…summarization (Steps 4-6)

- Relevance filtering: LLM batch-scores all papers (NOT_REL/REL-/REL/REL+) and removes irrelevant or low-completeness papers after each search round
- Quality evaluation: rule-based retry loop (≥3 REL/REL+ required, up to 3 iterations) with gap-filling query regeneration; raises NoRelevantPapersFound when exhausted
- PDF download: arXiv-only, stored in sessions/{id}/pdfs/; abstract fallback for non-arXiv papers
- Summarization: per-paper LLM call extracts Problem/Method/Results/Limitations from full PDF text (truncated to 32k chars) or abstract fallback
- Retry logic: _invoke_with_retry with exponential backoff for transient network errors
- UI progress bars: real-time query-by-query and paper-by-paper progress via thread-local callbacks into st.empty() placeholders
- Session improvements: pre-generated session UUID, quality_warning field, optional session_id in make_session(), legacy JSON backward-compat
- Test suite: 101 unit tests across 6 modules, no real network/API calls